### PR TITLE
Make the s3 root path configurable instead of hard coding to buffer-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Make sure you have the next variables in your environment:
 - `REDSHIFT_ENDPOINT`
 - `REDSHIFT_DB_NAME`
 - `REDSHIFT_DB_PORT`
+- `REDSHIFT_COPY_S3_ROOT # Root s3 bucket name for loading data into Redshift`
 
 ```python
 from rsdf import redshift

--- a/rsdf/redshift.py
+++ b/rsdf/redshift.py
@@ -72,7 +72,7 @@ def load_dataframe(dataframe, tablename, schemaname='public', columns=None, exis
     dataframe.to_csv(tfile.name, header=False, index=False, sep='|', compression='bz2', na_rep='')
 
     with smart_open(tfile) as tout:
-        with s3.open_buffer_data(s3_url, 'wb') as fout:
+        with s3.open(s3_url, 'wb') as fout:
             fout.write(tout.read())
 
     if columns is None:

--- a/rsdf/s3.py
+++ b/rsdf/s3.py
@@ -1,20 +1,21 @@
 import os
 from smart_open import smart_open
 
-creds = {
+env = {
     's3_access_key': os.environ.get('AWS_ACCESS_KEY_ID'),
-    's3_secret_key': os.environ.get('AWS_SECRET_ACCESS_KEY')
+    's3_secret_key': os.environ.get('AWS_SECRET_ACCESS_KEY'),
+    's3_root' : os.getenv('REDSHIFT_COPY_S3_ROOT')
 }
 
 
 def get_buffer_data_url(with_creds=False):
     if with_creds:
-        return 's3://{s3_access_key}:{s3_secret_key}@buffer-data'.format(**creds)
+        return 's3://{s3_access_key}:{s3_secret_key}@{s3_root}'.format(**env)
     else:
-        return 's3://buffer-data'
+        return 's3://{s3_root}'.format(**env)
 
 
-def open_buffer_data(path, mode='rb', **kw):
+def open(path, mode='rb', **kw):
     base_url = get_buffer_data_url(with_creds=True)
 
     s3_url = '{base_url}/{path}'.format(**locals())


### PR DESCRIPTION
Hey @davidgasquez! Would love your thoughts on this one! After switching this on to opensource, I released we where still hardcoding where we upload data for loading to Redshift. 

I made it configurable instead to use an ENV variable. This might impact how we're using the package internally, let me know your thoughts!