### PR TITLE
Add psycopg2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ smart_open
 pandas
 sqlalchemy
 numpy
+psycopg2


### PR DESCRIPTION
Hey guys,

I noticed there was a missing dependency in the `requirements.txt`: `psycopg2`.
